### PR TITLE
Fix issue where 'check' fails due to invalid flag to 'sort' utility.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-RUN apk add --no-cache curl bash jq
+RUN apk add --no-cache curl bash jq coreutils
 
 COPY in check /opt/resource/
 RUN chmod +x /opt/resource/*


### PR DESCRIPTION
Added the coreutils package to the Docker image as the "sort" utility that is available by default does not support the "-V" flag.