### PR TITLE
Switch to bash and fix shellcheck warnings.

### DIFF
--- a/check
+++ b/check
@@ -1,14 +1,12 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
 exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging
 
-payload=$(mktemp $TMPDIR/resource-check.XXXXXX)
+payload=$(mktemp "$TMPDIR/resource-check.XXXXXX")
 cat > "$payload" <&0
-
-version=$(jq -r '.version.version // empty' < "$payload")
 
 source_project=$(jq -r '.source.project // empty' < "$payload")
 if [[ "${source_project}X" == "X" ]]; then
@@ -16,12 +14,12 @@ if [[ "${source_project}X" == "X" ]]; then
   exit 1
 fi
 
-curl -sf https://releases.hashicorp.com/${source_project}/index.json > /dev/null || (
+curl -sf "https://releases.hashicorp.com/${source_project}/index.json" > /dev/null || (
   >&2 echo "Unknown hashicorp project '$source_project'"
   exit 1
 )
 >&2 echo "Looking up versions of '${source_project}'"
-latest_version=$(curl -s https://releases.hashicorp.com/${source_project}/index.json \
+latest_version=$(curl -s "https://releases.hashicorp.com/${source_project}/index.json" \
   | jq -r '.versions | keys[]' \
   | grep -v "beta" | grep -v "rc" | grep -v "alpha" \
   | sort -V | tail -n1)

--- a/in
+++ b/in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -7,7 +7,7 @@ exec 1>&2 # redirect all output to stderr for logging
 
 destination=$1
 
-payload=$(mktemp $TMPDIR/resource-check.XXXXXX)
+payload=$(mktemp "$TMPDIR/resource-check.XXXXXX")
 cat > "$payload" <&0
 
 version=$(jq -r '.version.version // empty' < "$payload")
@@ -24,30 +24,30 @@ fi
 
 params_regexp=$(jq -r '.params.regexp // empty' < "$payload")
 
-curl -sf https://releases.hashicorp.com/${source_project}/index.json > /dev/null || (
+curl -sf "https://releases.hashicorp.com/${source_project}/index.json" > /dev/null || (
   >&2 echo "Unknown hashicorp project '$source_project'"
   exit 1
 )
 
 >&2 echo "Fetching assets ${source_project} v${version}"
-cd $destination
+cd "$destination"
 echo "$version" > version
 echo "$source_project" > project
 
-build_urls=$(curl -s https://releases.hashicorp.com/${source_project}/index.json | jq -r ".versions[\"${version}\"].builds[].url")
+build_urls=$(curl -s "https://releases.hashicorp.com/${source_project}/index.json" | jq -r ".versions[\"${version}\"].builds[].url")
 if [[ ! -z $params_regexp ]]; then
   set +e
-  build_urls=$(echo "${build_urls}" | grep ${params_regexp})
+  build_urls=$(echo "${build_urls}" | grep "${params_regexp}")
   set -e
 fi
 if [[ ! -z $build_urls ]]; then
-  for url in "$build_urls"; do
+  for url in $build_urls; do
     >&2 echo "Downloading $url"
-    curl -O $url
+    curl -O "$url"
   done
 else
   >&2 echo "regexp '$params_regexp' did not match any build URLs"
   exit 1
 fi
 
-jq -n --arg version "${latest_version}" '{version: { version: $version }}' >&3
+jq -n --arg version "${version}" '{version: { version: $version }}' >&3


### PR DESCRIPTION
Resource scripts use features that are not standard in posix `sh`, such
as `[[]]` tests. Also, the `sh` that ships with alpine treats
`build_urls` as empty when not quoted in `[[ ! -z $build_urls ]]`.
Rather than handling edge cases in alpine `sh`, this patch switches to
`bash` and incidentally fixes some shellcheck warnings.

cc @drnic 